### PR TITLE
MCID

### DIFF
--- a/pydf.py
+++ b/pydf.py
@@ -6,7 +6,7 @@ import argparse
 import re
 
 
-__version__ = ('2.1.12')
+__version__ = ('2.1.13')
 __author__ = ('Shane King <kingaling_at_meatchicken_dot_net>')
 
 
@@ -18,6 +18,7 @@ def argbuilder():
     parser.add_argument("--no_summary",help="Showing the summary is the default. This disables it.", action="store_true")
     parser.add_argument("--show_json",help="Outputs pdf in json to the screen. Disabled by default.", action="store_true")
     jsongrp = parser.add_argument_group("json options")
+    jsongrp.add_argument("--show_text", help="* Include page text in json output", action="store_true")
     jsongrp.add_argument("--show_ttf", help="* Include true type fonts in json output", action="store_true")
     jsongrp.add_argument("--show_bitmap", help="* Include bitmaps in json output", action="store_true")
     jsongrp.add_argument("--show_pics", help="* Include pictures in json output", action="store_true")
@@ -60,6 +61,8 @@ def main():
         pdf_object.show_arbitrary = True
     if args.show_ttf or args.show_all:
         pdf_object.show_ttf = True
+    if args.show_text or args.show_all:
+        pdf_object.show_text = True
 
     pdf_object.max_size = int(args.max_size)
 

--- a/pydf2json/pydf2json.py
+++ b/pydf2json/pydf2json.py
@@ -15,7 +15,7 @@ except Exception as e:
     pass
 
 
-__version__ = ('2.1.12')
+__version__ = ('2.1.13')
 __author__ = ('Shane King <kingaling_at_meatchicken_dot_net>')
 
 
@@ -1222,6 +1222,7 @@ class PyDF2JSON(object):
             'xlsx': self.show_embedded_files,
             'zip': self.show_embedded_files,
             'arbitrary': self.show_arbitrary,
+            'pdf_mcid': self.show_text,
             'Unknown': True
         }
         decoded_streams = [
@@ -1459,11 +1460,29 @@ class PyDF2JSON(object):
                      'DSIG|EBDT|EBLC|EBSC|fpgm|gasp|hdmx|kern|LTSH|prep|PCLT|VDMX|vhea|vmtx)', my_stream[12:16]):
             stream_type = 'ttf'
 
-        if re.search('/MCID', my_stream) and \
-                re.search('(BDC|BMC)', my_stream) and \
-                re.search('EMC', my_stream) and \
-                re.search('BT', my_stream) and \
-                re.search('ET', my_stream):
+        #if re.search('/MCID', my_stream) and \
+        #        re.search('(BDC|BMC)', my_stream) and \
+        #        re.search('EMC', my_stream) and \
+        #        re.search('BT', my_stream) and \
+        #        re.search('ET', my_stream):
+        #    stream_type = 'pdf_mcid'
+
+        if (
+            re.search('MCID', my_stream) and
+            re.search('(BDC|BMC)', my_stream) and
+            re.search('EMC', my_stream) and
+            re.search('BT', my_stream) and
+            re.search('ET', my_stream) and
+            re.search('\[\(', my_stream)
+        ) or (
+            re.search('BT', my_stream) and
+            re.search('ET', my_stream) and (
+                re.search('TJ', my_stream) or
+                re.search('Tj', my_stream)
+            ) and
+            re.search('Tm', my_stream) and
+            re.search('\[\(', my_stream)
+        ):
             stream_type = 'pdf_mcid'
 
         if re.match('\x4D\x5A', my_stream[0:2]):

--- a/pydf2json/pydf2json.py
+++ b/pydf2json/pydf2json.py
@@ -46,6 +46,9 @@ class PyDF2JSON(object):
     # show_arbitrary: Arbitrary data found outside of any object. Default is False.
     show_arbitrary = False
 
+    # show_text: Show any decoded text streams. Default is false.
+    show_text = False
+
     # dump_streams: Dump streams to a temp location. Using this for LaikaBOSS objects.
     dump_streams = False
 

--- a/pydf2json/scripts/pydf.py
+++ b/pydf2json/scripts/pydf.py
@@ -6,7 +6,7 @@ import argparse
 import re
 
 
-__version__ = ('2.1.12')
+__version__ = ('2.1.13')
 __author__ = ('Shane King <kingaling_at_meatchicken_dot_net>')
 
 
@@ -18,6 +18,7 @@ def argbuilder():
     parser.add_argument("--no_summary",help="Showing the summary is the default. This disables it.", action="store_true")
     parser.add_argument("--show_json",help="Outputs pdf in json to the screen. Disabled by default.", action="store_true")
     jsongrp = parser.add_argument_group("json options")
+    jsongrp.add_argument("--show_text", help="* Include page text in json output", action="store_true")
     jsongrp.add_argument("--show_ttf", help="* Include true type fonts in json output", action="store_true")
     jsongrp.add_argument("--show_bitmap", help="* Include bitmaps in json output", action="store_true")
     jsongrp.add_argument("--show_pics", help="* Include pictures in json output", action="store_true")
@@ -60,6 +61,8 @@ def main():
         pdf_object.show_arbitrary = True
     if args.show_ttf or args.show_all:
         pdf_object.show_ttf = True
+    if args.show_text or args.show_all:
+        pdf_object.show_text = True
 
     pdf_object.max_size = int(args.max_size)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = open(os.path.join(here, 'README.rst'), 'rt').read()
 
 setup(
     name = 'pydf2json',
-    version = '2.1.12',
+    version = '2.1.13',
     packages=['pydf2json', 'pydf2json.scripts'],
     url = 'https://github.com/xamiel/pydf2json',
     license = 'GPL-3.0',


### PR DESCRIPTION
Added some functionality to parse the streams that contain postscript text objects.
Text can optionally be dumped and/or included in the output structure.
Now that this is done, the LaikaBOSS module can use Yara rules that can hit on the text body of a PDF like:
"You have a new secure document from Apple billing. Click here." <-- cool story.

This doesn't parse ALL text pages but most. There are some formats which I can't figure out yet. But it may be able to decode MOST of them.